### PR TITLE
Draft: FoldStreamAsync

### DIFF
--- a/src/EventStore.Client.Streams/EventStoreClient.Read.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Read.cs
@@ -114,20 +114,20 @@ namespace EventStore.Client {
 		}
 
 		/// <summary>
-		/// folds a stream using provided aggregator and seed
+		/// folds a stream using provided aggregator and seed.
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <typeparam name="E"></typeparam>
-		/// <param name="deserialize"></param>
-		/// <param name="aggregator"></param>
-		/// <param name="streamName"></param>
-		/// <param name="revision"></param>
-		/// <param name="seed"></param>
-		/// <param name="configureOperationOptions"></param>
-		/// <param name="resolveLinkTos"></param>
-		/// <param name="userCredentials"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <typeparam name="T">The type of the folded stated.</typeparam>
+		/// <typeparam name="E">The type of deserialized events.</typeparam>
+		/// <param name="deserialize">A deserialization function returning zero, one, or multiple events for a the given <see cref="ResolvedEvent"/>.</param>
+		/// <param name="aggregator">An aggregation function returning a new state from last state and current deserialized event.</param>
+		/// <param name="streamName">The name of the field to fold.</param>
+		/// <param name="revision">The <see cref="Position"/> of the first event to fold.</param>
+		/// <param name="seed">The seed state to start the aggregation.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns>A <see cref="FoldResult{T}"/> containing the aggregation result and the <see cref="StreamRevision"/> of the last event aggregated.</returns>
 		public async ValueTask<FoldResult<T>> FoldStreamAsync<T,E>(
 			Func<ResolvedEvent, IEnumerable<E>> deserialize,
 			Func<T,E,T> aggregator,
@@ -164,7 +164,7 @@ namespace EventStore.Client {
 
 			var hasNext = await call.MoveNextAsync(cancellationToken).ConfigureAwait(false);
 
-			StreamRevision rev =
+			var rev =
 				!hasNext || call.Current.ContentCase == ReadResp.ContentOneofCase.StreamNotFound
 					? StreamRevision.None
 					: StreamRevision.FromStreamPosition(revision);

--- a/src/EventStore.Client.Streams/EventStoreClient.Read.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Read.cs
@@ -116,11 +116,11 @@ namespace EventStore.Client {
 		/// <summary>
 		/// folds a stream using provided aggregator and seed.
 		/// </summary>
-		/// <typeparam name="T">The type of the folded stated.</typeparam>
+		/// <typeparam name="T">The type of the folded State.</typeparam>
 		/// <typeparam name="E">The type of deserialized events.</typeparam>
 		/// <param name="deserialize">A deserialization function returning zero, one, or multiple events for a the given <see cref="ResolvedEvent"/>.</param>
 		/// <param name="aggregator">An aggregation function returning a new state from last state and current deserialized event.</param>
-		/// <param name="streamName">The name of the field to fold.</param>
+		/// <param name="streamName">The name of the stream to fold.</param>
 		/// <param name="revision">The <see cref="Position"/> of the first event to fold.</param>
 		/// <param name="seed">The seed state to start the aggregation.</param>
 		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>

--- a/src/EventStore.Client.Streams/EventStoreClient.Read.cs
+++ b/src/EventStore.Client.Streams/EventStoreClient.Read.cs
@@ -165,7 +165,7 @@ namespace EventStore.Client {
 			var hasNext = await call.MoveNextAsync(cancellationToken).ConfigureAwait(false);
 
 			var rev =
-				!hasNext || call.Current.ContentCase == ReadResp.ContentOneofCase.StreamNotFound
+				hasNext && call.Current.ContentCase == ReadResp.ContentOneofCase.StreamNotFound
 					? StreamRevision.None
 					: StreamRevision.FromStreamPosition(revision);
 				

--- a/src/EventStore.Client.Streams/FoldResult.cs
+++ b/src/EventStore.Client.Streams/FoldResult.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+namespace EventStore.Client {
+	/// <summary>
+	///  Represents a fold result
+	/// </summary>
+	/// <typeparam name="T"></typeparam>
+	public struct FoldResult<T> {
+		/// <summary>
+		/// the position of the last event folded
+		/// </summary>
+		public StreamRevision Revision { get; }
+		/// <summary>
+		/// the fold value
+		/// </summary>
+		public T Value { get; }
+
+		/// <summary>
+		/// build a fold resuult
+		/// </summary>
+		/// <param name="revision"></param>
+		/// <param name="value"></param>
+		public FoldResult(StreamRevision revision, T value) {
+			Revision = revision;
+			Value = value;
+		}
+	}
+}

--- a/src/EventStore.Client.Streams/FoldResult.cs
+++ b/src/EventStore.Client.Streams/FoldResult.cs
@@ -1,24 +1,24 @@
 ﻿#nullable enable
 namespace EventStore.Client {
 	/// <summary>
-	///  Represents a fold result
+	///  Represents the result of a <see cref="EventStoreClient.FoldStreamAsync{T, E}(System.Func{ResolvedEvent, System.Collections.Generic.IEnumerable{E}}, System.Func{T, E, T}, string, StreamPosition, T, System.Action{EventStoreClientOperationOptions}?, bool, UserCredentials?, System.Threading.CancellationToken)" /> call.
 	/// </summary>
-	/// <typeparam name="T"></typeparam>
+	/// <typeparam name="T">The type of the aggregated state.</typeparam>
 	public struct FoldResult<T> {
 		/// <summary>
-		/// the position of the last event folded
+		/// The position of the last event aggregated.
 		/// </summary>
 		public StreamRevision Revision { get; }
 		/// <summary>
-		/// the fold value
+		/// The aggregation result.
 		/// </summary>
 		public T Value { get; }
 
 		/// <summary>
-		/// build a fold resuult
+		/// Build an instance of <see cref="FoldResult{T}"/>.
 		/// </summary>
-		/// <param name="revision"></param>
-		/// <param name="value"></param>
+		/// <param name="revision">The last event aggregated.</param>
+		/// <param name="value">The aggregation result.</param>
 		public FoldResult(StreamRevision revision, T value) {
 			Revision = revision;
 			Value = value;

--- a/test/EventStore.Client.Streams.Tests/fold_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/fold_stream.cs
@@ -126,7 +126,7 @@ namespace EventStore.Client {
 				new List<StreamPosition>());
 
 
-			var expected = StreamRevision.FromInt64(pos);
+			var expected = StreamRevision.FromInt64(pos-1);
 			Assert.Equal(expected, result.Revision);
 		}
 

--- a/test/EventStore.Client.Streams.Tests/fold_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/fold_stream.cs
@@ -108,6 +108,29 @@ namespace EventStore.Client {
 			Assert.Same(seed, result.Value);
 		}
 
+
+		[Fact]
+		public async Task fold_starting_after_last_event_has_position() {
+			var streamName = _fixture.GetStreamName();
+			const int pos = 20;
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => { acc.Add(e); return acc; },
+				streamName,
+				StreamPosition.FromInt64(pos),
+				new List<StreamPosition>());
+
+
+			var expected = StreamRevision.FromInt64(pos);
+			Assert.Equal(expected, result.Revision);
+		}
+
+
 		[Fact]
 		public async Task fold_starting_from_position_contains_expected_events () {
 			var streamName = _fixture.GetStreamName();

--- a/test/EventStore.Client.Streams.Tests/fold_stream.cs
+++ b/test/EventStore.Client.Streams.Tests/fold_stream.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using System.Collections.Generic;
+
+namespace EventStore.Client {
+	[Trait("Category", "Network")]
+	public class fold_stream : IClassFixture<fold_stream.Fixture> {
+		private readonly Fixture _fixture;
+
+		public fold_stream(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+
+		[Fact]
+		public async Task fold_is_called_for_each_event() {
+			var streamName = _fixture.GetStreamName();
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => { acc.Add(e); return acc; },
+				streamName,
+				StreamPosition.Start,
+				new List<StreamPosition>());
+
+			var expected =
+				Enumerable.Range(0, count)
+				.Select(p => new StreamPosition((ulong)p));
+
+			Assert.Equal(expected, result.Value);
+		}
+
+		[Fact]
+		public async Task fold_result_revision_is_last_event() {
+			var streamName = _fixture.GetStreamName();
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => acc + 1,
+				streamName,
+				StreamPosition.Start,
+				0);
+
+
+
+			Assert.Equal(StreamRevision.FromInt64 (count-1), result.Revision);
+		}
+
+
+		[Fact]
+		public async Task fold_result_revision_is_none_when_stream_doesnt_exist() {
+			var streamName = _fixture.GetStreamName();
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => acc + 1,
+				streamName,
+				StreamPosition.Start,
+				0);
+
+			Assert.Equal(StreamRevision.None, result.Revision);
+		}
+
+		[Fact]
+		public async Task fold_result_value_is_seed_when_stream_doesnt_exist() {
+			var streamName = _fixture.GetStreamName();
+
+			var seed = new object();
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => new object(),
+				streamName,
+				StreamPosition.Start,
+				seed);
+
+			Assert.Same(seed, result.Value);
+		}
+
+
+		[Fact]
+		public async Task fold_result_is_seed_if_all_events_are_deserialized_to_empty() {
+			var streamName = _fixture.GetStreamName();
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var seed = new object();
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => Array.Empty<int>(),
+				(acc, e) => new object(),
+				streamName,
+				StreamPosition.Start,
+				seed);
+
+
+
+			Assert.Same(seed, result.Value);
+		}
+
+		[Fact]
+		public async Task fold_starting_from_position_contains_expected_events () {
+			var streamName = _fixture.GetStreamName();
+			const int pos = 10;
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e.Event.EventNumber },
+				(acc, e) => { acc.Add(e); return acc; },
+				streamName,
+				StreamPosition.FromInt64(pos),
+				new List<StreamPosition>());
+
+
+			var expected =
+					Enumerable.Range(pos, count-pos)
+					.Select(p => new StreamPosition((ulong)p));
+
+			Assert.Equal(expected, result.Value);
+		}
+
+		[Fact]
+		public async Task fold_starting_from_start_contains_expected_events() {
+			var streamName = _fixture.GetStreamName();
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { e },
+				(acc, e) => { acc.Add(e.Event.EventNumber); return acc; },
+				streamName,
+				StreamPosition.Start,
+				new List<StreamPosition>());
+
+
+			var expected =
+					Enumerable.Range(0, count)
+					.Select(p => new StreamPosition((ulong)p));
+
+			Assert.Equal(expected, result.Value);
+		}
+
+
+		[Fact]
+		public async Task fold_with_deserializer_returning_multiple_events_process_them_in_order() {
+			var streamName = _fixture.GetStreamName();
+			const int count = 20;
+
+			await _fixture.Client.AppendToStreamAsync(streamName, StreamState.NoStream,
+				_fixture.CreateTestEvents(count));
+
+			var result = await _fixture.Client.FoldStreamAsync(
+				e => new[] { (e.Event.EventNumber, 0 ), ( e.Event.EventNumber, 1 ) },
+				(acc, e) => { acc.Add(e); return acc; },
+				streamName,
+				StreamPosition.Start,
+				new List<(StreamPosition,int)>());
+
+
+			var expected =
+					from p in Enumerable.Range(0, count)
+					from id in Enumerable.Range(0,2)
+					select (new StreamPosition((ulong)p), id);
+
+			Assert.Equal(expected, result.Value);
+		}
+
+
+		public class Fixture : EventStoreClientFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
This is a proposition for a FoldStreamAsync method on the .net client.
The goal is to make it easy to both fold the stream and get the last event number.
If you don't need the last event number, it not too compicated using Linq.Async:
```
client.ReadAsync(...).SelectMany(e => deserialize(e).ToAsyncEnumerable()).AggregateAsync(aggregator, seed);
```
The reason for the SelectMany is that, this way, the serializer can return an empty list to ignore an event, or a list with multiple value when a stored event would be better splitted in several events. In most cases the list contains a single element.
It is to be noted that a check on the client.ReadAsync result is necessary to avoid an exception on NotFound stream.

When appending an event to the stream, an expected version is required, and it should be the version of the last event.
In the code above, it means adding the version number along the results of the deserializer, the in the aggregator, maintaining the last version. it also has to be fed with the seed (this is not necessarily totally valid C# syntax):
```
   client.ReadAsync(..version..)
       .SelectMany(e => deserialize(e).Select(v => (v,e.Event.EventNumber)).ToAsyncEnumerable())
       .AggregateAsync(((_,state), (v,e)) => (v,aggregator(state,e)), (version, seed))
```
 This is doable but tedious and introduce several intermediate enumerable and tuples that will bloat the GC.

This PR propose an implementation of FoldAsync including this recurring pattern in a more integrated way.
```
 client.FoldAsync(deserialize, aggregator, streamname, revision, seed);
```
* The deserializer is a ResolvedEvent -> IEnumerable<E>.
* The aggregator a (T,E) -> T
* The seed a T.
The result is a structure that contains the final value of the aggregator and the revision of the last event

If the stream is empty of not found, it returns the seen with revision None or the input revision.

