### PR TITLE
fix: unnecessary http message handler invocation

### DIFF
--- a/src/KurrentDB.Client/Core/KurrentDBClientSettings.ConnectionString.cs
+++ b/src/KurrentDB.Client/Core/KurrentDBClientSettings.ConnectionString.cs
@@ -24,7 +24,7 @@ namespace KurrentDB.Client {
 			var settings = ConnectionStringParser.Parse(connectionString);
 
 			configure(settings);
-			
+
 			return settings;
 		}
 
@@ -258,9 +258,6 @@ namespace KurrentDB.Client {
 
 #if NET48
 				HttpMessageHandler CreateDefaultHandler() {
-					if (settings.CreateHttpMessageHandler is not null)
-						return settings.CreateHttpMessageHandler.Invoke();
-
 					var handler = new WinHttpHandler {
 						TcpKeepAliveEnabled = true,
 						TcpKeepAliveTime = settings.ConnectivitySettings.KeepAliveTimeout,

--- a/src/KurrentDB.Client/Streams/KurrentDBClient.cs
+++ b/src/KurrentDB.Client/Streams/KurrentDBClient.cs
@@ -25,11 +25,11 @@ namespace KurrentDB.Client {
 			AllowSynchronousContinuations = true
 		};
 
-		readonly ILogger<KurrentDBClient>  _log;
-		Lazy<StreamAppender>             _batchAppenderLazy;
-		StreamAppender                   BatchAppender => _batchAppenderLazy.Value;
-		readonly CancellationTokenSource _disposedTokenSource;
-		readonly IMessageSerializer      _messageSerializer;
+		readonly ILogger<KurrentDBClient> _log;
+		Lazy<StreamAppender>              _batchAppenderLazy;
+		StreamAppender                    BatchAppender => _batchAppenderLazy.Value;
+		readonly CancellationTokenSource  _disposedTokenSource;
+		readonly IMessageSerializer       _messageSerializer;
 
 		static readonly Dictionary<string, Func<RpcException, Exception>> ExceptionMap = new() {
 			[Constants.Exceptions.InvalidTransaction] = ex => new InvalidTransactionException(ex.Message, ex),
@@ -69,10 +69,10 @@ namespace KurrentDB.Client {
 		/// </summary>
 		/// <param name="settings"></param>
 		public KurrentDBClient(KurrentDBClientSettings? settings = null) : base(settings, ExceptionMap) {
-			_log = Settings.LoggerFactory?.CreateLogger<KurrentDBClient>() ?? new NullLogger<KurrentDBClient>();
+			_log                 = Settings.LoggerFactory?.CreateLogger<KurrentDBClient>() ?? new NullLogger<KurrentDBClient>();
 			_disposedTokenSource = new CancellationTokenSource();
-			_batchAppenderLazy = new Lazy<StreamAppender>(CreateStreamAppender);
-			
+			_batchAppenderLazy   = new Lazy<StreamAppender>(CreateStreamAppender);
+
 			_messageSerializer = MessageSerializer.From(settings?.Serialization);
 		}
 

--- a/test/KurrentDB.Client.Tests/ConnectionStringTests.cs
+++ b/test/KurrentDB.Client.Tests/ConnectionStringTests.cs
@@ -3,8 +3,6 @@ using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using AutoFixture;
-using KurrentDB.Client;
-using HashCode = KurrentDB.Client.HashCode;
 
 namespace KurrentDB.Client.Tests;
 
@@ -95,6 +93,23 @@ public class ConnectionStringTests {
 		}
 
 		static string MockingTone(string key) => new(key.Select((c, i) => i % 2 == 0 ? char.ToUpper(c) : char.ToLower(c)).ToArray());
+	}
+
+	[Fact]
+	public void connection_string_should_create_valid_http_handler() {
+		// Arrange
+		var settings = KurrentDBClientSettings.Create("kurrentdb://localhost:2113?tls=false");
+
+		// Act
+		var handler = settings.CreateHttpMessageHandler?.Invoke();
+
+		// Assert
+		Assert.NotNull(handler);
+#if NET48
+		Assert.IsType<WinHttpHandler>(handler);
+#else
+		Assert.IsType<SocketsHttpHandler>(handler);
+#endif
 	}
 
 	[Theory]


### PR DESCRIPTION
Fixes #343 

The http message handler was unnecessarily called when client settings were created, leading to infinite recursion in HTTP handler creation for the .NET 4.8 framework target