### PR TITLE
Allow specifying custom KurrentDB docker images in dispatch tests

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -4,15 +4,25 @@ on:
   workflow_call:
     inputs:
       kurrentdb-tag:
+        description: The docker tag to use. If kurrentdb-image is empty, the action will use the values in the KURRENTDB_DOCKER_IMAGES variable (ci, lts, previous-lts).
         required: true
         type: string
+      kurrentdb-image:
+        description: The docker image to use. Leave this empty to use the image in the KURRENTDB_DOCKER_IMAGES variable.
+        required: false
+        type: string
+      kurrentdb-registry:
+        description: The docker registry to use. Leave this empty to use the registry in the KURRENTDB_DOCKER_IMAGES variable.
+        required: false
+        type: string
       test:
+        description: Which test to run.
         required: true
         type: string
 env:
-  KURRENTDB_TAG: ${{ fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].tag}}
-  KURRENTDB_IMAGE: ${{ fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].image}}
-  KURRENTDB_REGISTRY: ${{ fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].registry}}
+  KURRENTDB_TAG: ${{ inputs.kurrentdb-image != '' && inputs.kurrentdb-tag || fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].tag }}
+  KURRENTDB_IMAGE: ${{ inputs.kurrentdb-image || fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].image }}
+  KURRENTDB_REGISTRY: ${{ inputs.kurrentdb-registry || fromJSON(vars.KURRENTDB_DOCKER_IMAGES)[inputs.kurrentdb-tag].registry }}
 jobs:
   test:
     timeout-minutes: 20

--- a/.github/workflows/dispatch-ee.yml
+++ b/.github/workflows/dispatch-ee.yml
@@ -4,13 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       kurrentdb-tag:
-        description: "KurrentDB tag"
+        description: "The KurrentDB docker tag to use. If kurrentdb-image is empty, the action will use the values in the KURRENTDB_DOCKER_IMAGES variable (ci, lts, previous-lts)."
         required: true
-        type: choice
-        options:
-          - ci
-          - lts
-          - previous-lts
+        type: string
+      kurrentdb-image:
+        description: "The KurrentDB docker image to test against. Leave this empty to use the image in the KURRENTDB_DOCKER_IMAGES variable"
+        required: false
+        type: string
+      kurrentdb-registry:
+        description: "The docker registry containing the KurrentDB docker image. Leave this empty to use the registry in the KURRENTDB_DOCKER_IMAGES variable."
+        required: false
+        type: string
 jobs:
   test:
     uses: ./.github/workflows/base.yml
@@ -21,5 +25,7 @@ jobs:
     name: Test (${{ inputs.kurrentdb-tag }})
     with:
       kurrentdb-tag: ${{ inputs.kurrentdb-tag }}
+      kurrentdb-image: ${{ inputs.kurrentdb-image }}
+      kurrentdb-registry: ${{ inputs.kurrentdb-registry }}
       test: ${{ matrix.test }}
     secrets: inherit


### PR DESCRIPTION
Allow specifying `kurrentdb-image` and `kurrentdb-registry`. If `kurrentdb-image` is provided, the `KURRENTDB_DOCKER_IMAGES` variable is not used.